### PR TITLE
feat: Play again? loop + optional colorama colors (dependency-free)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,14 @@ This started as an early 2019 learning project and has been iteratively moderniz
 ## Features
 
 - **Difficulty levels**: Easy (8 guesses), Medium (6), Hard (5)
+- **Play again?** loop after win or lose
 - Random word selection from a curated built-in list or optional `words.txt`
 - Progressive ASCII hangman stages
 - Correct handling of duplicate letters (all occurrences revealed at once)
 - Robust input validation (single letter, already-guessed, non-letters, case-insensitive)
 - Remaining-guess counter after every turn
 - Clear win / lose feedback with emoji
-- Zero external runtime dependencies
+- **Optional colored output** via `colorama` (fully optional — zero hard dependencies)
 - Fully typed helpers + comprehensive `pytest` suite
 - GitHub Actions CI (flake8 + pytest)
 
@@ -32,6 +33,7 @@ This started as an early 2019 learning project and has been iteratively moderniz
 3. Guess one letter at a time (uppercase is accepted and normalized).
 4. A correct guess reveals every matching letter. A miss advances the hangman drawing.
 5. Reveal the full word before you run out of guesses.
+6. After the round, choose whether to play again.
 
 ## Example Gameplay
 
@@ -70,6 +72,9 @@ You have 6 guesses remaining.
 
 🎉 Congratulations! You guessed the word correctly!
 The word was: constant
+
+Play again? (y/n) [default: n]: n
+Thanks for playing! Goodbye.
 ```
 
 ## Installation & Running
@@ -79,6 +84,16 @@ git clone https://github.com/deepakv30/Hangman.git
 cd Hangman
 python hangman.py
 ```
+
+### Optional: Colored output
+
+For colored terminal messages (green for correct, red for wrong, etc.):
+
+```bash
+pip install colorama
+```
+
+The game works perfectly without it — colors are completely optional.
 
 ### Optional: Custom word list
 
@@ -94,6 +109,7 @@ pytest tests/ -v
 ## Tech Stack
 
 - Python 3.x (standard library only at runtime)
+- Optional: `colorama` for colored output
 - Type hints throughout
 - pytest + flake8 in CI
 
@@ -131,7 +147,6 @@ Most recommended improvements are now complete.
 
 **Optional next steps:**
 - [ ] Short terminal GIF or screenshot in the README
-- [ ] Optional “Play again?” loop
 - [ ] Package as an installable CLI tool
 
 ## Contributing

--- a/hangman.py
+++ b/hangman.py
@@ -2,6 +2,22 @@ import random
 from pathlib import Path
 from typing import List, Set
 
+# Optional color support — keeps the game fully dependency-free.
+# Install with: pip install colorama
+try:
+    from colorama import Fore, Style, init as colorama_init
+
+    colorama_init(autoreset=True)
+    GREEN = Fore.GREEN
+    RED = Fore.RED
+    YELLOW = Fore.YELLOW
+    CYAN = Fore.CYAN
+    RESET = Style.RESET_ALL
+    COLORS_ENABLED = True
+except ImportError:
+    GREEN = RED = YELLOW = CYAN = RESET = ""
+    COLORS_ENABLED = False
+
 HANGMAN_STAGES = [
     r"""
       +---+
@@ -165,8 +181,8 @@ def select_difficulty() -> str:
 
 
 def play_hangman(difficulty: str | None = None) -> None:
-    """Main function to play the Hangman game with ASCII art."""
-    print("Welcome to Hangman!")
+    """Main function to play one round of the Hangman game with ASCII art."""
+    print(f"{CYAN}Welcome to Hangman!{RESET}")
     print("Guess the hidden word letter by letter.\n")
 
     if difficulty is None:
@@ -190,10 +206,10 @@ def play_hangman(difficulty: str | None = None) -> None:
         guessed_letters.add(guess)
 
         if guess in word:
-            print(f"Good guess! '{guess}' is in the word.")
+            print(f"{GREEN}Good guess! '{guess}' is in the word.{RESET}")
         else:
             wrong_guesses += 1
-            print(f"Sorry, '{guess}' is not in the word.")
+            print(f"{RED}Sorry, '{guess}' is not in the word.{RESET}")
             # Clamp index so we never go out of range
             stage_index = min(wrong_guesses, len(HANGMAN_STAGES) - 1)
             print(HANGMAN_STAGES[stage_index])
@@ -202,7 +218,7 @@ def play_hangman(difficulty: str | None = None) -> None:
         print(current_display)
 
         if current_display == word:
-            print("\n🎉 Congratulations! You guessed the word correctly!")
+            print(f"\n{GREEN}🎉 Congratulations! You guessed the word correctly!{RESET}")
             print(f"The word was: {word}")
             return
 
@@ -211,9 +227,20 @@ def play_hangman(difficulty: str | None = None) -> None:
         print(f"Guessed letters so far: {', '.join(sorted(guessed_letters))}")
         print(f"You have {remaining} {guess_word} remaining.\n")
 
-    print("\n😢 Game Over! You ran out of guesses.")
+    print(f"\n{RED}😢 Game Over! You ran out of guesses.{RESET}")
     print(f"The word was: {word}")
 
 
+def main() -> None:
+    """Entry point with optional play-again loop."""
+    while True:
+        play_hangman()
+        again = input(f"\n{YELLOW}Play again? (y/n) [default: n]: {RESET}").strip().lower()
+        if again not in ("y", "yes"):
+            print("Thanks for playing! Goodbye.")
+            break
+        print()  # blank line between rounds
+
+
 if __name__ == "__main__":
-    play_hangman()
+    main()


### PR DESCRIPTION
## Summary

Implements the two requested **low-impact** items:

### 1. “Play again?” loop
- After a win or loss the player is asked: `Play again? (y/n) [default: n]`
- Answering `y` / `yes` starts a new round (difficulty is selected again)
- Any other answer (or empty) exits cleanly with a goodbye message

### 2. Optional color output with `colorama`
- Tries to import `colorama` at startup
- If available → colored messages (green = correct, red = wrong / game over, cyan = welcome, yellow = prompt)
- If **not** installed → falls back to plain text (no error, zero hard dependencies)
- Documented in the README with a simple `pip install colorama` note

## Testing
- Existing unit tests are unaffected (they do not depend on the new entry-point loop or colors)
- Manual verification recommended: play a round → choose y → play another → choose n

## Notes
- Runtime remains fully dependency-free unless the user chooses to install `colorama`
- No changes to core game logic or difficulty system

Ready for review!